### PR TITLE
fix: Correct YAML syntax in issue templates

### DIFF
--- a/.github/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F41B Bug report"
-about: 버그를 발견했을 때 작성해주세요
+about: "버그를 발견했을 때 작성해주세요"
 title: "[BUG] "
 labels: "bug"
 ---

--- a/.github/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F4A1 Feature request"
-about: 새로운 기능이나 개선 아이디어를 제안해주세요
+about: "새로운 기능이나 개선 아이디어를 제안해주세요"
 title: "[FEAT] "
 labels: "enhancement"
 ---


### PR DESCRIPTION
## 🚀 작업 배경

이슈 생성 시, 사전에 정의한 `bug_report` 및 `feature_request` 템플릿이 나타나지 않는 문제가 발생했습니다.

---

## 🛠️ 주요 변경 사항

문제 원인이었던 이슈 템플릿 파일(`.md`) 상단의 YAML 설정부(frontmatter) 문법 오류를 수정했습니다.

- `name`과 `about` 필드의 값에 따옴표(`"`)를 추가하여 GitHub의 파서(Parser)가 정상적으로 인식하도록 변경했습니다.
- 이 수정으로 인해 템플릿 기능이 다시 활성화되었습니다.