### PR TITLE
feat(BE): Configure Database Profiles and Initial Security

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,26 @@
+# docker-compose up -d
+# docker-compose logs -f
+# docker-compose down (docker-compose down -v)
+
+# 실행하려는 컨테이너 그룹
+services:
+  db:
+    # 사용할 도커 이미지 -> postgres 15 버전
+    image: postgres:15
+
+    # 컨테이너의 이름
+    container_name: lifelogix-db
+
+    # 컨테이너 내부 환경 변수 -> PostgreSQL 컨테이너 초기 DB 설정
+    environment:
+      - POSTGRES_USER=lifelogix     # 데이터베이스 사용자 이름
+      - POSTGRES_PASSWORD=lifelogix # 데이터베이스 비밀번호
+      - POSTGRES_DB=lifelogix       # 데이터베이스 이름
+
+    # 포트 연결 -> 내 PC(호스트)의 5432 포트로 오는 요청을 컨테이너의 5432 포트로 전달
+    ports:
+      - "5432:5432"
+
+    # 데이터를 영속적으로 저장하기 위해 볼륨 연결
+    volumes:
+      - ./data:/var/lib/postgresql/data

--- a/backend/src/main/java/com/lifelogix/config/SecurityConfig.java
+++ b/backend/src/main/java/com/lifelogix/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.lifelogix.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // REST API 서버의 Stateless -> CSRF(Cross-Site Request Forgery) 보호 기능 비활성화
+                .csrf(csrf -> csrf.disable())
+
+                // HTTP 요청에 대한 인가 규칙 설정
+                .authorizeHttpRequests(authz -> authz
+                        // "/" 경로를 포함한 모든 요청("/**")에 대해 접근을 허용
+                        .requestMatchers("/**").permitAll()
+                        // 그 외 나머지 요청은 인증이 필요 (현재는 위 규칙 때문에 미작동)
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/lifelogix/controller/HomeController.java
+++ b/backend/src/main/java/com/lifelogix/controller/HomeController.java
@@ -1,0 +1,13 @@
+package com.lifelogix.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+
+    @GetMapping("/")
+    public String home() {
+        return "Welcome to LifeLogix!";
+    }
+}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,14 @@
+spring:
+  # 도커 컴포즈 환경 변수 참고
+  datasource:
+    url: jdbc:postgresql://localhost:5432/lifelogix
+    username: lifelogix
+    password: lifelogix
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: local

--- a/backend/src/test/java/com/lifelogix/LifelogixApplicationTests.java
+++ b/backend/src/test/java/com/lifelogix/LifelogixApplicationTests.java
@@ -2,7 +2,9 @@ package com.lifelogix;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class LifelogixApplicationTests {
 

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    # H2를 PostgreSQL처럼 사용하기 위해 MODE=PostgreSQL 추가
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop # 테스트 시작 시 스키마 생성, 종료 시 삭제
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect # H2 DB 방언 명시


### PR DESCRIPTION
## 🚀 작업 배경

본격적인 TDD 사이클에 진입하기 전, 안정적인 백엔드 개발 환경을 구축하는 것을 목표로 합니다.

테스트 환경과 로컬 개발 환경을 완벽히 분리하여 테스트의 격리성을 보장하고, 도커를 통해 모든 팀원이 동일한 데이터베이스 환경을 공유할 수 있도록 설정하였습니다. 또한, 향후 인증/인가 기능을 점진적으로 개발하기 위한 토대로서 스프링 시큐리티의 기본 설정을 추가하였습니다.

---

## 🛠️ 주요 변경 사항

1.  **Spring Profile 기반 환경 분리**
    * `test`: 테스트 코드는 `src/test/resources/application-test.yml` 설정을 통해 H2 인메모리 데이터베이스를 사용합니다.
    * `local`: 로컬 개발 환경은 `src/main/resources/application-local.yml` 설정을 통해 PostgreSQL 데이터베이스를 사용합니다.

2.  **Docker Compose를 이용한 로컬 DB 환경 구성**
    * 프로젝트 루트에 `docker-compose.yml` 파일을 추가하여, 명령어 한 줄로 모든 팀원이 동일한 PostgreSQL 개발 환경을 구성할 수 있도록 했습니다.

3.  **Spring Security 기본 설정 추가**
    * 모든 요청(`/**`)을 임시로 허용하는 `SecurityConfig`를 추가하여, 추후 보안 규칙을 강화할 수 있는 기반을 마련했습니다.

4.  **테스트 코드 및 검증 컨트롤러 추가**
    * `@SpringBootTest`가 `test` 프로파일로 실행되도록 `@ActiveProfiles("test")`를 적용하고, H2 환경에서 테스트가 성공하는 것을 확인했습니다.
    * 애플리케이션 구동 및 `local` 프로파일 연결을 검증하기 위한 임시 `HomeController`를 추가했습니다.

---

## 🔗 관련 이슈

- **Closes #9**