### PR TITLE
feat(deploy): Add Dockerfile for Render deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,32 @@
+# --- 1단계: Gradle을 사용하여 프로젝트 빌드 ---
+# Gradle 8.5와 Java 17을 포함한 이미지를 빌드 환경으로 사용
+FROM gradle:8.5.0-jdk17 AS build
+
+# 작업 디렉토리 설정
+WORKDIR /home/gradle/project
+
+# Gradle 빌드에 필요한 파일들만 먼저 복사하여 Docker 캐시 활용 극대화
+COPY build.gradle settings.gradle gradlew ./
+COPY gradle ./gradle
+
+# 소스 코드 전체 복사
+COPY src ./src
+
+# Gradle Wrapper에 실행 권한 부여
+RUN chmod +x ./gradlew
+
+# Gradle을 사용하여 프로젝트를 빌드하고 실행 가능한 jar 파일 생성
+RUN ./gradlew build --no-daemon
+
+
+# --- 2단계: 빌드된 jar 파일을 실행 ---
+# 더 가벼운 Java 17 실행 환경(JRE) 이미지 사용
+FROM openjdk:17-jre-slim
+
+# 이전 빌드 단계에서 생성된 jar 파일을 실행 환경으로 복사
+# build/libs/lifelogix-0.0.1-SNAPSHOT.jar 파일을 app.jar 라는 이름으로 복사
+COPY --from=build /home/gradle/project/build/libs/lifelogix-0.0.1-SNAPSHOT.jar app.jar
+
+# 애플리케이션 실행 명령어
+# 서버가 시작될 때 "java -jar /app.jar" 명령어가 실행
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
## 🚀 작업 배경

Render 배포 과정에서 프로젝트가 Java가 아닌 Node.js 환경으로 잘못 인식되어 `JAVA_HOME`을 찾지 못하는 빌드 실패 문제가 지속적으로 발생했습니다. 이 문제를 해결하고, 어떤 배포 환경에서든 일관된 빌드와 실행을 보장하기 위해 Docker를 도입하기로 결정했습니다.

---

## 🛠️ 주요 변경 사항

- **`Dockerfile` 추가**:
  - `backend` 디렉토리에 멀티 스테이지 빌드(multi-stage build) 방식의 `Dockerfile`을 추가했습니다.
  - **빌드 스테이지**: Gradle JDK 17 이미지를 사용하여 프로젝트를 안전하게 빌드하고 실행 가능한 `.jar` 파일을 생성합니다.
  - **실행 스테이지**: 경량화된 OpenJDK JRE 이미지를 사용하여 빌드된 `.jar` 파일을 실행함으로써, 최종 이미지의 용량을 최적화했습니다.

- **Render 설정 변경**:
  - Render 웹 서비스의 Runtime을 `Docker`로 변경하고, `backend/Dockerfile`을 사용하도록 경로를 지정했습니다.
  - 기존의 Build/Start Command와 불필요해진 `RENDER_JAVA_VERSION` 환경 변수를 제거했습니다.

---

## 🔗 관련 이슈

- 없습니다.