### PR TITLE
fix(deploy): Use stable eclipse-temurin Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,8 +20,8 @@ RUN ./gradlew build --no-daemon
 
 
 # --- 2단계: 빌드된 jar 파일을 실행 ---
-# 더 가벼운 Java 17 실행 환경(JRE) 이미지 사용
-FROM openjdk:17-jre-slim
+# 안정적인 Eclipse Temurin JRE 이미지 사용
+FROM eclipse-temurin:17-jre-jammy
 
 # 이전 빌드 단계에서 생성된 jar 파일을 실행 환경으로 복사
 # build/libs/lifelogix-0.0.1-SNAPSHOT.jar 파일을 app.jar 라는 이름으로 복사


### PR DESCRIPTION
## 🚀 작업 배경

Render 배포 과정에서 Dockerfile의 실행(runtime) 스테이지가 `openjdk:17-jre-slim` 이미지를 찾지 못하여 빌드가 실패하는 오류가 발생했습니다. 해당 이미지 태그가 Docker Hub에서 더 이상 지원되지 않거나 변경된 것으로 보입니다.

---

## 🛠️ 주요 변경 사항

- `Dockerfile`의 실행 스테이지 베이스 이미지를 `openjdk:17-jre-slim`에서 보다 안정적이고 널리 사용되는 `eclipse-temurin:17-jre-jammy`로 변경했습니다.
- 이를 통해 Docker 이미지 PULL 단계의 안정성을 확보하고 배포 실패 문제를 해결합니다.

---

## 🔗 관련 이슈

- 없습니다.