### PR TITLE
fix(deploy): Use 'update' for ddl-auto on initial deployment

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## 🚀 작업 배경

Render에 첫 배포를 진행하는 과정에서, 애플리케이션이 시작되지 않고 `Error starting ApplicationContext` 오류가 발생했습니다. 로그 분석 결과, `application-prod.yml`에 설정된 `ddl-auto: validate` 옵션이 원인이었습니다. 이 옵션은 DB 테이블이 이미 존재함을 가정하고 검증을 시도하지만, 새로 생성된 데이터베이스는 비어있기 때문에 테이블을 찾지 못해 스프링 컨텍스트 로딩에 실패했습니다.

---

## 🛠️ 주요 변경 사항

- `application-prod.yml` 파일의 `spring.jpa.hibernate.ddl-auto` 설정을 `validate`에서 `update`로 변경했습니다.
- 이를 통해 첫 배포 시, Spring Data JPA가 엔티티 클래스를 기반으로 필요한 모든 데이터베이스 테이블을 자동으로 생성하게 하여 애플리케이션이 정상적으로 시작될 수 있도록 수정했습니다.

---

## 🔗 관련 이슈

- 없습니다.