### PR TITLE
fix(deploy): Explicitly set DataSource URL from environment variable

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,5 +1,8 @@
 # Render 배포 환경(prod) 전용 설정
 spring:
+  datasource:
+    url: ${DATABASE_URL}
+    driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 🚀 작업 배경

`ddl-auto: update` 설정 후 재배포 시, Spring Boot가 Render의 `DATABASE_URL` 환경 변수를 자동으로 감지하지 못해 `Failed to configure a DataSource` 오류가 발생하며 애플리케이션 시작에 실패했습니다.

---

## 🛠️ 주요 변경 사항

- `application-prod.yml` 파일에 `spring.datasource.url` 속성을 명시적으로 추가하고, Render가 제공하는 `${DATABASE_URL}` 환경 변수를 값으로 지정했습니다.
- 또한, 드라이버 클래스를 찾는 데 실패하는 경우를 방지하기 위해 `spring.datasource.driver-class-name`을 `org.postgresql.Driver`로 명시했습니다.
- 이를 통해 Spring Boot가 배포 환경의 데이터베이스를 확실하게 찾고 연결할 수 있도록 수정했습니다.

---

## 🔗 관련 이슈

- 없습니다.