### PR TITLE
fix(deploy): Prepend JDBC prefix to database URL

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 # Render 배포 환경(prod) 전용 설정
 spring:
   datasource:
-    url: ${DATABASE_URL}
+    url: jdbc:${DATABASE_URL}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
## 🚀 작업 배경

Render 배포 시, Spring Boot 애플리케이션이 `Driver claims to not accept jdbcUrl` 오류를 발생시키며 데이터베이스에 연결하지 못하는 문제가 발생했습니다. 원인은 Render가 제공하는 `DATABASE_URL` (`postgresql://...`)이 JDBC 표준 주소 형식(`jdbc:postgresql://...`)과 맞지 않기 때문이었습니다.

---

## 🛠️ 주요 변경 사항

- `application-prod.yml` 파일의 `spring.datasource.url` 설정을 `jdbc:${DATABASE_URL}`로 수정했습니다.
- 이를 통해 `postgresql://` 주소 앞에 `jdbc:` 접두사를 명시적으로 추가하여, PostgreSQL JDBC 드라이버가 정상적으로 인식하고 연결할 수 있도록 문제를 해결했습니다.

---

## 🔗 관련 이슈

- 없습니다.