### PR TITLE
fix(deploy): Construct standard JDBC URL from individual DB variables

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,7 +1,9 @@
 # Render 배포 환경(prod) 전용 설정
 spring:
   datasource:
-    url: jdbc:${DATABASE_URL}
+    url: jdbc:postgresql://${PGHOST}:${PGPORT}/${PGDATABASE}
+    username: ${PGUSER}
+    password: ${PGPASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
## 🚀 작업 배경

Render 배포 시, `DATABASE_URL`을 직접 사용하여 JDBC URL을 구성했을 때 `Driver claims to not accept jdbcUrl` 오류가 발생하며 DB 연결에 실패했습니다. 이는 Render가 제공하는 URI 형식(`postgresql://user:pass@host/...`)과 JDBC 드라이버가 기대하는 표준 형식(`jdbc:postgresql://host:port/...`) 간의 불일치 때문이었습니다.

---

## 🛠️ 주요 변경 사항

- `application-prod.yml` 파일에서 단일 `DATABASE_URL`을 사용하는 대신, Render가 제공하는 개별 환경 변수들(`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`)을 조합하여 표준 JDBC URL을 생성하도록 설정을 변경했습니다.
- 이를 통해 JDBC 드라이버가 주소 형식을 명확하게 인식하고 데이터베이스에 성공적으로 연결할 수 있도록 문제를 해결했습니다.

---

## 🔗 관련 이슈

- 없습니다.