### PR TITLE
chore(BE): Configure server port for deployment environment

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,3 +1,6 @@
+server:
+  port: ${PORT}
+
 # Render 배포 환경(prod) 전용 설정
 spring:
   datasource:


### PR DESCRIPTION
## 🚀 작업 배경

Render에 배포된 백엔드 애플리케이션이 하드코딩된 `8080` 포트를 사용하고 있어 외부 요청을 수신하지 못하는 문제가 발생했습니다. 이로 인해 프론트엔드에서 회원가입 등 API 요청 시 `socket hang up` 오류가 나타나며 통신에 실패했습니다.

본 작업은 Render와 같은 클라우드 환경에서 동적으로 할당하는 포트를 애플리케이션이 사용할 수 있도록 설정을 변경하여 배포 문제를 해결하는 것을 목표로 합니다.

---

## 🛠️ 주요 변경 사항

- **application-prod.yml 파일 수정:** `server.port` 설정을 추가하여, Render 플랫폼에서 제공하는 `${PORT}` 환경 변수 값을 읽어오도록 변경했습니다. 이를 통해 애플리케이션이 배포 환경에 맞는 포트에서 실행되도록 수정했습니다.

---

## 🔗 관련 이슈

- 없습니다.