### PR TITLE
fix(deploy): Resolve deployment and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ hs_err_pid*
 ### Gradle ###
 .gradle
 backend/build/
+backend/bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -144,3 +145,32 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+
+# =========================================
+# Frontend (Next.js)
+# =========================================
+
+# Dependencies
+/frontend/node_modules
+
+# Build directory
+/frontend/.next
+
+# Production build
+/frontend/out
+
+# Local environment variables
+/frontend/.env*.local
+
+# Log files
+/frontend/npm-debug.log*
+/frontend/yarn-debug.log*
+/frontend/yarn-error.log*
+/frontend/pnpm-debug.log*
+
+# Next.js cache
+/frontend/.vercel
+
+# Editor directories and files
+.vscode

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,4 +29,4 @@ COPY --from=build /home/gradle/project/build/libs/lifelogix-0.0.1-SNAPSHOT.jar a
 
 # 애플리케이션 실행 명령어
 # 서버가 시작될 때 "java -jar /app.jar" 명령어가 실행
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+CMD ["java", "-Dserver.port=${PORT}", "-jar", "/app.jar"]


### PR DESCRIPTION
## 🚀 작업 배경

Render 배포 시 `Timed out` 오류가 발생하며 지속적으로 실패하는 문제가 있었습니다. 원인 분석 결과, Docker 컨테이너에서 실행되는 Spring Boot 애플리케이션이 Render가 지정하는 `PORT` 환경 변수를 인식하지 못하고 기본 포트 `8080`으로 실행되는 것이 확인되었습니다.

또한, `.gitignore` 파일에 프론트엔드(Next.js)와 백엔드(Gradle)의 빌드 결과물 및 의존성 폴더(`node_modules`, `.next`, `bin/` 등)에 대한 설정이 누락되어 불필요한 파일들이 Git 추적 대상에 포함될 위험이 있었습니다.

---

## 🛠️ 주요 변경 사항

이번 커밋은 두 가지 주요 문제를 해결합니다.

1.  **`Dockerfile` 수정 (배포 실패 해결)**
    * `CMD` 실행 명령어에 `-Dserver.port=${PORT}` 인수를 추가했습니다.
    * 이를 통해 Spring Boot 애플리케이션이 시작될 때 Render의 `PORT` 환경 변수 값을 강제로 사용하도록 하여, 배포 환경과의 포트 불일치 문제를 해결했습니다.

2.  **`.gitignore` 개선 (버전 관리 효율화)**
    * 프론트엔드 관련: `node_modules`, `.next`, `.env.local` 등 Next.js 프로젝트에서 제외해야 할 항목들을 추가했습니다.
    * 백엔드 관련: Gradle 빌드 시 생성되는 `bin/` 폴더를 추가했습니다.

---

## 🔗 관련 이슈

-   없습니다.