### PR TITLE
fix(BE): Isolate and correct environment profiles

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -12,4 +12,5 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
-JWT_SECRET: 'a2VlcGl0c2VjcmV0Zm9ybGlmZWxvZ2l4cHJvamVjdGJ5dGFjdA=='
+jwt:
+  secret: 'a2VlcGl0c2VjcmV0Zm9ybGlmZWxvZ2l4cHJvamVjdGJ5dGFjdA=='

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,6 +1,9 @@
 server:
   port: ${PORT}
 
+jwt:
+  secret: ${JWT_SECRET}
+
 # Render 배포 환경(prod) 전용 설정
 spring:
   datasource:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,13 +1,10 @@
 # 모든 환경에 적용되는 공통 설정
-spring:
-  profiles:
-    active: local
-  jpa:
-    # JPA 관련 공통 설정
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
+jpa:
+  # JPA 관련 공통 설정
+  properties:
+    hibernate:
+      show_sql: true
+      format_sql: true
 
 # JWT 관련 공통 설정
 jwt:


### PR DESCRIPTION
## 🚀 작업 배경

로그인 후 지속적으로 발생하던 `401 Unauthorized` 인증 오류를 해결하기 위해 백엔드 설정을 점검했습니다. 근본 원인은 배포 및 로컬 환경 간의 프로필(profile) 설정이 모호하고 일부 잘못되어, JWT Secret Key가 일치하지 않는 문제였습니다.

---

## 🛠️ 주요 변경 사항

- **`application.yml`**: 모든 환경에 대한 공통 설정만 남기고, 기본 활성 프로필 지정을 제거하여 실행 환경에서 프로필을 명시적으로 선택하도록 강제했습니다.
- **`application-prod.yml`**: 배포 환경의 JWT Secret Key 설정을 명시적으로 추가하여, `prod` 프로필이 항상 `JWT_SECRET` 환경 변수를 사용하도록 보장합니다.
- **`application-local.yml`**: 로컬 환경의 JWT Secret Key 설정이 잘못된 YAML 형식으로 작성되어 있던 문제를 수정하여, 키가 정상적으로 로드되도록 변경했습니다.

이러한 변경을 통해 환경별 설정이 명확하게 분리되고, 배포 시 발생할 수 있는 설정 오류 가능성을 원천적으로 차단합니다.

---

## 🔗 관련 이슈

- 관련된 이슈가 없습니다.