### PR TITLE
feat(BE): Refactor test code to align with local profile

### DIFF
--- a/backend/src/test/java/com/lifelogix/timeline/activity/api/controller/ActivityControllerTest.java
+++ b/backend/src/test/java/com/lifelogix/timeline/activity/api/controller/ActivityControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -36,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(ActivityController.class)
 @Import({SecurityConfig.class, ActivityControllerTest.TestConfig.class})
+@ActiveProfiles("local")
 @DisplayName("ActivityController 통합 테스트")
 class ActivityControllerTest {
 

--- a/backend/src/test/java/com/lifelogix/timeline/category/api/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/lifelogix/timeline/category/api/controller/CategoryControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -34,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(CategoryController.class)
 @Import({SecurityConfig.class, CategoryControllerTest.TestConfig.class})
+@ActiveProfiles("local")
 @DisplayName("CategoryController 통합 테스트")
 class CategoryControllerTest {
 

--- a/backend/src/test/java/com/lifelogix/timeline/core/api/controller/TimelineControllerTest.java
+++ b/backend/src/test/java/com/lifelogix/timeline/core/api/controller/TimelineControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
@@ -40,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(TimelineController.class)
 @Import({SecurityConfig.class, TimelineControllerTest.TestConfig.class})
+@ActiveProfiles("local")
 @DisplayName("TimelineController 통합 테스트")
 class TimelineControllerTest {
 

--- a/backend/src/test/java/com/lifelogix/user/api/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/lifelogix/user/api/controller/AuthControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Map;
@@ -34,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AuthController.class)
 @Import({SecurityConfig.class, AuthControllerTest.TestConfig.class})
+@ActiveProfiles("local")
 @DisplayName("AuthController 통합 테스트")
 class AuthControllerTest {
 

--- a/backend/src/test/java/com/lifelogix/user/api/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/lifelogix/user/api/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.given;
@@ -26,7 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
-@Import({SecurityConfig.class, UserControllerTest.TestConfig.class}) // TestConfig Import
+@Import({SecurityConfig.class, UserControllerTest.TestConfig.class})
+@ActiveProfiles("local") // TestConfig Import
 @DisplayName("UserController 통합 테스트")
 class UserControllerTest {
 


### PR DESCRIPTION
## 🚀 작업 배경

Render 배포를 위해 백엔드 애플리케이션의 기본 프로필이 `prod`로 설정되어 있습니다. 이로 인해, 별도의 프로필 설정이 없는 테스트 코드가 `prod` 환경 설정을 따라가게 되어 `application-local.yml`에 정의된 로컬 테스트용 설정을 읽지 못하는 문제가 발생했습니다. 특히, JWT 시크릿 값 등이 달라 테스트가 실패하는 원인이 되었습니다.

---

## 🛠️ 주요 변경 사항

이 문제를 해결하기 위해 Spring Boot의 웹 통합 테스트(`@WebMvcTest`) 코드에 `@ActiveProfiles("local")` 어노테이션을 추가했습니다.

- **적용 대상:**
  - `ActivityControllerTest.java`
  - `CategoryControllerTest.java`
  - `TimelineControllerTest.java`
  - `AuthControllerTest.java`
  - `UserControllerTest.java`

- **변경 결과:**
  - 이제 해당 테스트들은 실행 시 `local` 프로필을 우선적으로 사용하게 됩니다.
  - 이를 통해 `application-local.yml`에 정의된 설정을 정상적으로 불러와 테스트가 성공적으로 통과합니다.
  - 실제 배포 환경(prod)에는 영향을 주지 않고 오직 테스트 환경에만 적용됩니다.

---

## 🔗 관련 이슈

- 관련된 이슈가 없습니다.