### PR TITLE
fix(ci): Increase gradle wrapper timeout to prevent build failure

### DIFF
--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
-networkTimeout=10000
+networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 🚀 작업 배경

1.  **테스트 프로필 설정:** Render 배포를 위해 백엔드 기본 프로필을 `prod`로 설정함에 따라, 로컬 테스트 환경에서 `application-local.yml` 설정을 사용하지 못해 테스트가 실패하는 문제가 있었습니다.
2.  **JWT 인증 오류:** 로그인 후 대시보드 등 인증이 필요한 페이지에 접근 시, 백엔드에서 401 Unauthorized 오류를 반환하며 인증에 실패하는 문제가 발생했습니다. 근본 원인은 토큰 생성과 검증에 사용되는 두 라이브러리(`jjwt`, `Nimbus`) 간의 키 처리 방식 비호환성으로 추정되었습니다.
3.  **배포(CI) 실패:** Render 배포 환경에서 `gradlew build` 실행 시, Gradle 배포판을 다운로드하는 과정에서 네트워크 타임아웃(10초)이 발생하여 빌드가 실패했습니다.

---

## 🛠️ 주요 변경 사항

### 1. 테스트 코드 프로필 설정

- 모든 웹 통합 테스트(`@WebMvcTest`) 클래스에 `@ActiveProfiles("local")` 어노테이션을 추가하여, 테스트 실행 시 `local` 프로필을 명시적으로 사용하도록 수정했습니다.
- 이를 통해 테스트가 로컬 환경 설정(`application-local.yml`)을 정상적으로 사용하게 되어 빌드 실패 문제를 해결했습니다.

### 2. JWT 처리 로직 통합 (ADR-006 준수)

- **키 처리 방식 통일:** `JwtTokenProvider`의 키 생성 로직을 `SecretKeySpec`을 직접 사용하도록 변경하여, 토큰 생성(`jjwt`)과 검증(`Nimbus`) 라이브러리 간의 키 처리 방식을 완벽하게 일치시켰습니다.
- **역할 분리:** `JwtTokenProvider`에서 유효성 검증 관련 코드를 모두 제거하고, 순수하게 토큰 생성 역할만 담당하도록 리팩토링했습니다.
- **검증 로직 일원화:** `UserService`가 리프레시 토큰을 검증할 때, Spring Security의 표준 `JwtDecoder`를 주입받아 사용하도록 수정하여 모든 토큰 검증 로직을 표준 구현체로 통합했습니다.
- `UserServiceTest` 또한 변경된 `UserService`의 의존성 및 로직에 맞게 수정했습니다.

### 3. CI 빌드 안정성 확보

- `gradle/wrapper/gradle-wrapper.properties` 파일의 `networkTimeout` 값을 `10000`(10초)에서 `60000`(60초)으로 상향 조정했습니다.
- 이를 통해 네트워크 환경이 불안정한 CI/CD 환경에서도 Gradle 배포판을 안정적으로 다운로드할 수 있도록 하여 배포 실패를 방지합니다.

---

## 🔗 관련 이슈

- 관련된 이슈가 없습니다.