### PR TITLE
fix(FE): Centralize logout logic to fix redirect loop

### DIFF
--- a/frontend/app/(protected)/mypage/page.tsx
+++ b/frontend/app/(protected)/mypage/page.tsx
@@ -8,16 +8,12 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
-import { User, Mail, Calendar, LogOut, Trophy, Sparkles } from "lucide-react"
-import { useToast } from "@/hooks/use-toast"
-import { AIGoalPlanner } from "@/components/ai-goal-planner"
-import { GamificationPanel } from "@/components/gamification-panel"
-import { api } from "@/lib/api"
+import { useAuth } from "@/context/AuthContext"
 
 export default function MyPage() {
   const router = useRouter()
   const { toast } = useToast()
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const { logout } = useAuth()
   const [stats, setStats] = useState({ categories: 0, activities: 0 })
   // TODO: Fetch user info from a /api/users/me endpoint
   const [userInfo, setUserInfo] = useState({
@@ -29,9 +25,10 @@ export default function MyPage() {
   useEffect(() => {
     const token = localStorage.getItem("accessToken")
     if (!token) {
+      // This should theoretically not be reached due to ProtectedLayout
+      // but as a fallback, we redirect.
       router.push("/login")
     } else {
-      setIsAuthenticated(true)
       fetchData(token)
     }
   }, [router])
@@ -45,20 +42,18 @@ export default function MyPage() {
       const activityCount = activityGroups.reduce((acc, group) => acc + group.activities.length, 0)
       setStats({ categories: categories.length, activities: activityCount })
       // Once user info API is available, fetch and set it here
-      // e.g., const user = await api.getMe(); setUserInfo(user);
+      // e.g., const user = await api.getMe(token); setUserInfo(user);
     } catch (error) {
       toast({ title: "데이터 로드 실패", variant: "destructive" })
     }
   }
 
   const handleLogout = () => {
-    localStorage.removeItem("accessToken")
-    localStorage.removeItem("refreshToken")
+    logout()
     toast({
       title: "로그아웃 완료",
       description: "다시 로그인해주세요",
     })
-    router.push("/login")
   }
 
   if (!isAuthenticated) {

--- a/frontend/components/dashboard-header.tsx
+++ b/frontend/components/dashboard-header.tsx
@@ -3,15 +3,15 @@
 import { Button } from "@/components/ui/button"
 import { LogOut, Settings, User, Users, Home, CalendarDays, Scale } from "lucide-react"
 import { ThemeToggle } from "@/components/theme-toggle"
-import { useRouter, usePathname } from "next/navigation"
+import { useAuth } from "@/context/AuthContext"
 
 export function DashboardHeader() {
   const router = useRouter()
   const pathname = usePathname()
+  const { logout } = useAuth()
 
   const handleLogout = () => {
-    localStorage.removeItem("accessToken")
-    router.push("/login")
+    logout()
   }
 
   const navItems = [


### PR DESCRIPTION
## 🚀 작업 배경

로그아웃 시 `로그인 페이지`와 `대시보드` 사이에서 무한 리디렉션 루프가 발생하는 버그가 있었습니다. 원인은 `AuthContext`의 중앙 인증 상태가 업데이트되기 전에 라우팅이 먼저 일어나면서 발생하는 **경쟁 상태(Race Condition)** 때문이었습니다.

`mypage`와 `dashboard-header` 컴포넌트에서 각각 `localStorage`를 직접 비우고 `/login`으로 리디렉션하는 로컬 로그아웃 로직을 가지고 있었습니다. 이로 인해 `AuthContext`의 `isAuthenticated` 상태는 여전히 `true`로 남아있었고, `/login` 페이지는 인증된 사용자로 판단하여 `/dashboard`로 다시 리디렉션하면서 무한 루프가 시작되었습니다.

---

## 🛠️ 주요 변경 사항

이 문제를 해결하기 위해 로그아웃 로직을 중앙에서 관리하도록 리팩토링했습니다.

- **로그아웃 로직 중앙화**: `mypage/page.tsx`와 `components/dashboard-header.tsx`에 있던 개별적인 로그아웃 로직을 제거했습니다.
- **`useAuth` 훅 사용**: 두 컴포넌트 모두 `AuthContext`에서 제공하는 `logout` 함수를 호출하도록 수정했습니다. 이를 통해 로그아웃 시 인증 상태를 먼저 업데이트한 후 리디렉션을 수행하여, 상태 불일치로 인한 무한 루프 문제를 해결했습니다.

---

## 🔗 관련 이슈

- 관련된 이슈가 없습니다.